### PR TITLE
Add DB.iterator helper api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - iterator-api
 jobs:
   manylinux:
     runs-on: ubuntu-latest
@@ -14,6 +15,7 @@ jobs:
         with:
           submodules: recursive
       - name: Cache .a files
+        id: build-cache
         uses: actions/cache@v2
         with:
           key: ${{ runner.os }}
@@ -25,8 +27,9 @@ jobs:
             src/rocksdb/libz.a
             src/rocksdb/librocksdb.a
       - name: Install requirements
-        run: sudo apt-get install build-essential binutils cmake
+        run: sudo apt-get install build-essential binutils cmake python3-cffi
       - name: Make static library files
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: make clean && make
       - name: Build wheels
         run: /bin/bash scripts/build.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include rocksdb/cpp/*.hpp
 recursive-include rocksdb *.pxd
 recursive-include rocksdb *.pyx

--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -2440,6 +2440,7 @@ cdef class BaseIterator(object):
         return ret
 
     def __reversed__(self):
+        self.seek_to_last()
         return ReversedIterator(self)
 
     cpdef seek_to_first(self):

--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -1949,7 +1949,7 @@ cdef class DB(object):
             st = self.db.Write(opts, batch.batch)
         check_status(st)
 
-    def iterator(self, start: bytes, column_family: bytes = None, iterate_lower_bound: bytes = None,
+    def iterator(self, start: bytes, column_family: ColumnFamilyHandle = None, iterate_lower_bound: bytes = None,
                  iterate_upper_bound: bytes = None, reverse: bool = False, include_key: bool = True,
                  include_value: bool = True, fill_cache: bool = True, prefix_same_as_start: bool = False,
                  auto_prefix_mode: bool = False):
@@ -1957,7 +1957,7 @@ cdef class DB(object):
         RocksDB Iterator
 
         Args:
-            column_family (bytes):        the name of the column family
+            column_family (ColumnFamilyHandle):  column family handle
             start (bytes):                prefix to seek to
             iterate_lower_bound (bytes):  defines the smallest key at which the backward iterator can return an entry.
                                           Once the bound is passed, Valid() will be false. `iterate_lower_bound` is
@@ -2003,23 +2003,21 @@ cdef class DB(object):
                           The iterator supports being `reversed`
         """
 
-        cf = self.get_column_family(column_family)
-
         if not include_value:
             iterator = self.iterkeys(
-                column_family=cf, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
+                column_family=column_family, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
                 iterate_lower_bound=iterate_lower_bound, iterate_upper_bound=iterate_upper_bound,
                 auto_prefix_mode=auto_prefix_mode
             )
         elif not include_key:
             iterator = self.itervalues(
-                column_family=cf, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
+                column_family=column_family, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
                 iterate_lower_bound=iterate_lower_bound, iterate_upper_bound=iterate_upper_bound,
                 auto_prefix_mode=auto_prefix_mode
             )
         else:
             iterator = self.iteritems(
-                column_family=cf, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
+                column_family=column_family, fill_cache=fill_cache, prefix_same_as_start=prefix_same_as_start,
                 iterate_lower_bound=iterate_lower_bound, iterate_upper_bound=iterate_upper_bound,
                 auto_prefix_mode=auto_prefix_mode
             )

--- a/rocksdb/options.pxd
+++ b/rocksdb/options.pxd
@@ -172,10 +172,15 @@ cdef extern from "rocksdb/options.h" namespace "rocksdb":
         cpp_bool disableWAL
 
     cdef cppclass ReadOptions:
+        const Snapshot* snapshot
+        const Slice* iterate_lower_bound
+        const Slice* iterate_upper_bound
+        size_t readahead_size
         cpp_bool verify_checksums
         cpp_bool fill_cache
-        const Snapshot* snapshot
         ReadTier read_tier
+        cpp_bool prefix_same_as_start
+        cpp_bool auto_prefix_mode
 
     cdef cppclass FlushOptions:
         cpp_bool wait

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -723,8 +723,9 @@ class TestDBColumnFamilies(TestHelper):
             b'A': rocksdb.ColumnFamilyOptions(),
             b'B': rocksdb.ColumnFamilyOptions()
         }
-        secondary = rocksdb.get_db_with_options(
-            os.path.join(self.db_loc, "test"), create_if_missing=True, max_open_files=-1,
+        secondary = rocksdb.DB(
+            os.path.join(self.db_loc, "test"),
+            rocksdb.Options(create_if_missing=True, max_open_files=-1),
             secondary_name=secondary_location, column_families=cf
         )
         self.addCleanup(secondary.close)
@@ -781,11 +782,11 @@ class TestPrefixIterator(TestHelper):
         self.assertListEqual(
             [(b'a0', b'a0_value'), (b'a1', b'a1_value'), (b'a1b', b'a1b_value'), (b'a2b', b'a2b_value'),
              (b'a3', b'a3_value'), (b'a4', b'a4_value')],
-            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b', prefix_same_as_start=True))
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b'))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
-            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b', prefix_same_as_start=True, include_value=False))
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b', include_value=False))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
@@ -885,37 +886,37 @@ class TestPrefixIteratorWithExtractor(TestHelper):
         self.assertListEqual(
             [(b'a0', b'a0_value'), (b'a1', b'a1_value'), (b'a1b', b'a1b_value'), (b'a2b', b'a2b_value'),
              (b'a3', b'a3_value'), (b'a4', b'a4_value')],
-            list(map(lambda x: (x[0][-1], x[1]), self.db.iterator(column_family=b'first', start=b'a', prefix_same_as_start=True)))
+            list(map(lambda x: (x[0][-1], x[1]), self.db.iterator(column_family=cf_a, start=b'a', prefix_same_as_start=True)))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
-            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a', include_value=False, prefix_same_as_start=True)))
+            list(map(lambda x: x[-1], self.db.iterator(column_family=cf_a, start=b'a', include_value=False, prefix_same_as_start=True)))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
-            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a5', include_value=False)))
+            list(map(lambda x: x[-1], self.db.iterator(column_family=cf_a, start=b'a0', iterate_upper_bound=b'a5', include_value=False)))
         )
         self.assertListEqual(
             [b'a4', b'a3', b'a2b', b'a1b', b'a1', b'a0'],
             list(map(lambda x: x[-1],
                 reversed(self.db.iterator(
-                    column_family=b'first', start=b'a0', iterate_upper_bound=b'a5', include_value=False
+                    column_family=cf_a, start=b'a0', iterate_upper_bound=b'a5', include_value=False
                 ))))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b', b'a2b', b'a3'],
-            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a4', include_value=False)))
+            list(map(lambda x: x[-1], self.db.iterator(column_family=cf_a, start=b'a0', iterate_upper_bound=b'a4', include_value=False)))
         )
         self.assertListEqual(
             [b'a0', b'a1', b'a1b'],
-            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a2', include_value=False)))
+            list(map(lambda x: x[-1], self.db.iterator(column_family=cf_a, start=b'a0', iterate_upper_bound=b'a2', include_value=False)))
         )
         self.assertListEqual(
             [b'a1b', b'a1', b'a0'],
             list(map(lambda x: x[-1], reversed(
-                self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a2', include_value=False))))
+                self.db.iterator(column_family=cf_a, start=b'a0', iterate_upper_bound=b'a2', include_value=False))))
         )
         self.assertListEqual(
             [b'b0'],
-            list(map(lambda x: x[-1], self.db.iterator(column_family=b'second', start=b'b', include_value=False)))
+            list(map(lambda x: x[-1], self.db.iterator(column_family=cf_b, start=b'b', include_value=False)))
         )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -9,8 +9,10 @@ import struct
 import tempfile
 from rocksdb.merge_operators import UintAddOperator, StringAppendOperator
 
+
 def int_to_bytes(ob):
     return str(ob).encode('ascii')
+
 
 class TestHelper(unittest.TestCase):
 
@@ -69,6 +71,24 @@ class TestDB(TestHelper):
         secondary.try_catch_up_with_primary()
         self.assertEqual(b"b", secondary.get(b"a"))
 
+        secondary2_location = os.path.join(self.db_loc, "secondary2")
+        secondary2 = rocksdb.DB(
+            os.path.join(self.db_loc, "test"),
+            rocksdb.Options(create_if_missing=True, max_open_files=-1),
+            secondary_name=secondary2_location
+        )
+        self.addCleanup(secondary2.close)
+
+        self.assertEqual(b"b", secondary2.get(b"a"))
+        self.db.put(b"a", b"c")
+        self.assertEqual(b"b", secondary.get(b"a"))
+        self.assertEqual(b"b", secondary2.get(b"a"))
+        self.assertEqual(b"c", self.db.get(b"a"))
+        secondary.try_catch_up_with_primary()
+        secondary2.try_catch_up_with_primary()
+        self.assertEqual(b"c", secondary.get(b"a"))
+        self.assertEqual(b"c", secondary2.get(b"a"))
+
     def test_multi_get(self):
         self.db.put(b"a", b"1")
         self.db.put(b"b", b"2")
@@ -97,6 +117,18 @@ class TestDB(TestHelper):
         ret = self.db.multi_get([b'key', b'a'])
         self.assertEqual(ref, ret)
 
+    def test_write_batch_context(self):
+        with self.db.write_batch() as batch:
+            batch.put(b"key", b"v1")
+            batch.delete(b"key")
+            batch.put(b"key", b"v2")
+            batch.put(b"key", b"v3")
+            batch.put(b"a", b"b")
+
+        ref = {b'a': b'b', b'key': b'v3'}
+        ret = self.db.multi_get([b'key', b'a'])
+        self.assertEqual(ref, ret)
+
     def test_write_batch_iter(self):
         batch = rocksdb.WriteBatch()
         self.assertEqual([], list(batch))
@@ -119,7 +151,6 @@ class TestDB(TestHelper):
             ('Merge', b'xxx', b'value')
         ]
         self.assertEqual(ref, list(it))
-
 
     def test_key_may_exists(self):
         self.db.put(b"a", b'1')
@@ -173,7 +204,6 @@ class TestDB(TestHelper):
         reverse_it = reversed(it)
         it.seek_for_prev(b'c3')
         self.assertEqual(it.get(), (b'c2', b'c2_value'))
-
 
     def test_iter_keys(self):
         for x in range(300):
@@ -457,6 +487,7 @@ class StaticPrefix(rocksdb.interfaces.SliceTransform):
     def in_range(self, dst):
         return len(dst) == 5
 
+
 class TestPrefixExtractor(TestHelper):
     def setUp(self):
         TestHelper.setUp(self)
@@ -687,15 +718,29 @@ class TestDBColumnFamilies(TestHelper):
         self.assertEqual({(cfa, b'a'): b'1', (cfa, b'b'): b'2'}, dict(it))
 
     def test_get_property(self):
+        secondary_location = os.path.join(self.db_loc, "secondary")
+        cf = {
+            b'A': rocksdb.ColumnFamilyOptions(),
+            b'B': rocksdb.ColumnFamilyOptions()
+        }
+        secondary = rocksdb.get_db_with_options(
+            os.path.join(self.db_loc, "test"), create_if_missing=True, max_open_files=-1,
+            secondary_name=secondary_location, column_families=cf
+        )
+        self.addCleanup(secondary.close)
+
         for x in range(300):
             x = int_to_bytes(x)
             self.db.put((self.cf_a, x), x)
 
-        self.assertEqual(b"300",
-                         self.db.get_property(b'rocksdb.estimate-num-keys',
-                                              self.cf_a))
-        self.assertIsNone(self.db.get_property(b'does not exsits',
-                                               self.cf_a))
+        self.assertIsNone(self.db.get_property(b'does not exsits', self.cf_a))
+        self.assertEqual(b"0", secondary.get_property(b'rocksdb.estimate-num-keys', secondary.get_column_family(b'A')))
+        self.assertEqual(b"300", self.db.get_property(b'rocksdb.estimate-num-keys', self.cf_a))
+
+        secondary.try_catch_up_with_primary()
+
+        self.assertEqual(b"300", secondary.get_property(b'rocksdb.estimate-num-keys', secondary.get_column_family(b'A')))
+        self.assertEqual(b"300", self.db.get_property(b'rocksdb.estimate-num-keys', self.cf_a))
 
     def test_compact_range(self):
         for x in range(10000):
@@ -704,3 +749,173 @@ class TestDBColumnFamilies(TestHelper):
 
         self.db.compact_range(column_family=self.cf_b)
 
+
+class OneCharacterPrefix(rocksdb.interfaces.SliceTransform):
+    def name(self):
+        return b'test prefix'
+
+    def transform(self, src):
+        return (0, 1)
+
+    def in_domain(self, src):
+        return len(src) >= 1
+
+    def in_range(self, dst):
+        return len(dst) == 1
+
+
+class TestPrefixIterator(TestHelper):
+    def setUp(self):
+        TestHelper.setUp(self)
+        opts = rocksdb.Options(create_if_missing=True)
+        self.db = rocksdb.DB(os.path.join(self.db_loc, 'test'), opts)
+
+    def test_iterator(self):
+        self.db.put(b'a0', b'a0_value')
+        self.db.put(b'a1', b'a1_value')
+        self.db.put(b'a1b', b'a1b_value')
+        self.db.put(b'a2b', b'a2b_value')
+        self.db.put(b'a3', b'a3_value')
+        self.db.put(b'a4', b'a4_value')
+        self.db.put(b'b0', b'b0_value')
+        self.assertListEqual(
+            [(b'a0', b'a0_value'), (b'a1', b'a1_value'), (b'a1b', b'a1b_value'), (b'a2b', b'a2b_value'),
+             (b'a3', b'a3_value'), (b'a4', b'a4_value')],
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b', prefix_same_as_start=True))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b', prefix_same_as_start=True, include_value=False))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a5', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a4', b'a3', b'a2b', b'a1b', b'a1', b'a0'],
+            list(reversed(self.db.iterator(start=b'a0', iterate_upper_bound=b'a5', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a4', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a1b', b'a1', b'a0'],
+            list(reversed(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b0', include_value=False))
+        )
+
+
+class TestPrefixIteratorWithExtractor(TestHelper):
+    def setUp(self):
+        TestHelper.setUp(self)
+        opts = rocksdb.Options(create_if_missing=True)
+        opts.prefix_extractor = OneCharacterPrefix()
+        self.db = rocksdb.DB(os.path.join(self.db_loc, 'test'), opts)
+
+    def test_iterator(self):
+        self.db.put(b'a0', b'a0_value')
+        self.db.put(b'a1', b'a1_value')
+        self.db.put(b'a1b', b'a1b_value')
+        self.db.put(b'a2b', b'a2b_value')
+        self.db.put(b'a3', b'a3_value')
+        self.db.put(b'a4', b'a4_value')
+        self.db.put(b'b0', b'b0_value')
+        self.assertListEqual(
+            [(b'a0', b'a0_value'), (b'a1', b'a1_value'), (b'a1b', b'a1b_value'), (b'a2b', b'a2b_value'),
+             (b'a3', b'a3_value'), (b'a4', b'a4_value')],
+            list(self.db.iterator(start=b'a', prefix_same_as_start=True))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a', include_value=False, prefix_same_as_start=True))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a5', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a4', b'a3', b'a2b', b'a1b', b'a1', b'a0'],
+            list(reversed(self.db.iterator(start=b'a0', iterate_upper_bound=b'a5', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a4', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b'],
+            list(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False))
+        )
+        self.assertListEqual(
+            [b'a1b', b'a1', b'a0'],
+            list(reversed(self.db.iterator(start=b'a0', iterate_upper_bound=b'a2', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(self.db.iterator(start=b'a', iterate_upper_bound=b'b0', include_value=False))
+        )
+
+    def test_column_family_iterator(self):
+        cf_a = self.db.create_column_family(b'first', rocksdb.ColumnFamilyOptions())
+        cf_b = self.db.create_column_family(b'second', rocksdb.ColumnFamilyOptions())
+
+        self.db.put((cf_a, b'a0'), b'a0_value')
+        self.db.put((cf_a, b'a1'), b'a1_value')
+        self.db.put((cf_a, b'a1b'), b'a1b_value')
+        self.db.put((cf_a, b'a2b'), b'a2b_value')
+        self.db.put((cf_a, b'a3'), b'a3_value')
+        self.db.put((cf_a, b'a4'), b'a4_value')
+        self.db.put((cf_b, b'b0'), b'b0_value')
+
+        self.assertListEqual(
+            [(b'a0', b'a0_value'), (b'a1', b'a1_value'), (b'a1b', b'a1b_value'), (b'a2b', b'a2b_value'),
+             (b'a3', b'a3_value'), (b'a4', b'a4_value')],
+            list(map(lambda x: (x[0][-1], x[1]), self.db.iterator(column_family=b'first', start=b'a', prefix_same_as_start=True)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a', include_value=False, prefix_same_as_start=True)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3', b'a4'],
+            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a5', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a4', b'a3', b'a2b', b'a1b', b'a1', b'a0'],
+            list(map(lambda x: x[-1],
+                reversed(self.db.iterator(
+                    column_family=b'first', start=b'a0', iterate_upper_bound=b'a5', include_value=False
+                ))))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b', b'a2b', b'a3'],
+            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a4', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a0', b'a1', b'a1b'],
+            list(map(lambda x: x[-1], self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a2', include_value=False)))
+        )
+        self.assertListEqual(
+            [b'a1b', b'a1', b'a0'],
+            list(map(lambda x: x[-1], reversed(
+                self.db.iterator(column_family=b'first', start=b'a0', iterate_upper_bound=b'a2', include_value=False))))
+        )
+        self.assertListEqual(
+            [b'b0'],
+            list(map(lambda x: x[-1], self.db.iterator(column_family=b'second', start=b'b', include_value=False)))
+        )


### PR DESCRIPTION
- adds `DB.iterator` method to access different types of iterators (keys / values / pairs of keys and values) easily and to do prefix/range scans, supports column families
- add context manager wrapper for `DB.write_batch`
