### PR TITLE
Require cython in the build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+  "Cython >= 0.20",
+  "setuptools >= 58.3",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,7 @@ setup(
     author_email="jackrobison@lbry.com",
     url="https://github.com/lbryio/lbry-rocksdb",
     license='BSD License',
-	python_requires=">=3.7.0",
-    setup_requires=['setuptools>=25', 'Cython>=0.20'],
-    install_requires=['setuptools>=25'],
+    python_requires=">=3.7.0",
     package_dir={'rocksdb': 'rocksdb'},
     packages=find_packages('.'),
     ext_modules=cythonize([Extension(


### PR DESCRIPTION
I was confused seeing `setuptools` in a `install_requires`. Usually, that section is for dependencies that a python project wants available at runtime. I did not see anywhere in the code (other than setup.py) where `setuptools` is imported, so install_requires is removed entirely.

I'm taking a bit of a leap here in using https://setuptools.pypa.io/en/latest/history.html#v58-3-0 to begin making use of PEP 518, but seeing as how this project is python 3.7+, it should be okay. In fact, it should probably be https://setuptools.pypa.io/en/latest/history.html#v59-7-0 or higher.

The rationale for this change is to be able to pip install a package that depends on this rocksdb package. Failing to install cython first on modern versions of setuptools without this PEP 518 pyproject.toml.