### PR TITLE
Support more manylinux containers

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,1 +1,1 @@
-docker run --rm -v $(pwd):/lbry-rocksdb quay.io/pypa/manylinux_2_24_x86_64 /bin/bash lbry-rocksdb/scripts/make-wheels.sh
+docker run --rm -v $(pwd):/lbry-rocksdb quay.io/pypa/manylinux2014_x86_64 /bin/bash lbry-rocksdb/scripts/make-wheels.sh

--- a/scripts/make-wheels.sh
+++ b/scripts/make-wheels.sh
@@ -1,7 +1,5 @@
 set -ex
 
-apt install -y binutils
-
 cd lbry-rocksdb
 mkdir -p dist
 


### PR DESCRIPTION
When the container I was using could not find a wheel file, I ended up looking at the support matrix that's in https://github.com/pypa/manylinux documentation:
<img width="862" alt="image" src="https://user-images.githubusercontent.com/4098674/155423700-b733edec-9e04-4aa7-be23-85513508f7e9.png">

This PR aims to stick with manylinux2014 version as a way to support centos 7/8, ubuntu20.04, and others.

Here's a listing of the wheels artifact after downloading:
```
lbry_rocksdb-0.8.2-cp37-cp37m-macosx_10_14_x86_64.whl
lbry_rocksdb-0.8.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
lbry_rocksdb-0.8.2-cp38-cp38-macosx_10_14_x86_64.whl
lbry_rocksdb-0.8.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
lbry_rocksdb-0.8.2-cp39-cp39-macosx_10_15_x86_64.whl
lbry_rocksdb-0.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
lbry_rocksdb-0.8.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```

tested here https://github.com/kevinkjt2000/lbry-rocksdb/actions/runs/1889958952