### PR TITLE
Update to 6.29.4 plus 752fea5d4400198bc8a591b7d795d1c8d5f12230

### DIFF
--- a/rocksdb/__init__.py
+++ b/rocksdb/__init__.py
@@ -1,4 +1,4 @@
 from ._rocksdb import *
 
-ROCKSDB_VERSION = '6.25.3'  # 0103296f39ec3fd89b4cdda9687c63fde90eec24
+ROCKSDB_VERSION = '6.29.4'  # ad155621274f6bb459fe390c7be268f2a22191a6
 __version__ = "0.8.2"


### PR DESCRIPTION
Experimental... I don't know whether there are missing changes local to lbryio/lbry-rocksdb here, as I constructed this by doing:

git checkout origin/6.29.fb
git cherry-pick 752fea5d4400198bc8a591b7d795d1c8d5f12230

The latter is the zlib bump from Mar 2022.

Underlying goal is to fix the clang build issue by updating to a version that contains: https://github.com/facebook/rocksdb/pull/9374